### PR TITLE
Fix the issue of modeling_llama.LlamaRotaryEmbedding.forward being changed to an invalid method.

### DIFF
--- a/qai_hub_models/models/_shared/llama3/model.py
+++ b/qai_hub_models/models/_shared/llama3/model.py
@@ -297,10 +297,11 @@ def monkey_patch_huggingface_llama_modeling():
         return position_ids
 
     # Bypass rotary_emb module
-    modeling_llama.LlamaRotaryEmbedding._original_forward = (
-        modeling_llama.LlamaRotaryEmbedding.forward
-    )
-    modeling_llama.LlamaRotaryEmbedding.forward = bypass_RotaryEmbedding
+    if hasattr(modeling_llama.LlamaRotaryEmbedding, "_original_forward") == False:
+        modeling_llama.LlamaRotaryEmbedding._original_forward = (
+            modeling_llama.LlamaRotaryEmbedding.forward
+        )
+        modeling_llama.LlamaRotaryEmbedding.forward = bypass_RotaryEmbedding
     modeling_llama.apply_rotary_pos_emb = QcLlama_apply_rotary_pos_emb
 
     def LlamaRMSNorm_forward(self, hidden_states):


### PR DESCRIPTION
The lines are called multiple times when export llama 3_2_3b:
https://github.com/quic/ai-hub-models/blob/main/qai_hub_models/models/_shared/llama3/model.py#L300-L302

Both modeling_llama.LlamaRotaryEmbedding.forward and modeling_llama.LlamaRotaryEmbedding._original_forward will be set to bypass_RotaryEmbedding, and bypass_RotaryEmbedding just return position_ids, that's not correct values (its shape and its contained data are incorrect), please refer to: 
 https://github.com/quic/ai-hub-models/blob/main/qai_hub_models/models/_shared/llama3/model.py#L125-L137

**This line will raise exception when prepare the inference jobs:**
       ` emb_size = embeddings[0].size(-1) // 2`

So, this patch adds the condition to ensure
modeling_llama.LlamaRotaryEmbedding._original_forward only be set to modeling_llama.LlamaRotaryEmbedding.forward once.

Local tests are passed:
The step of inference jobs works correctly,
![image](https://github.com/user-attachments/assets/c9325798-8a0f-4928-ad67-ca3ff7cf520f)