### PR TITLE
Add soundfile to execute yamnet demo application

### DIFF
--- a/qai_hub_models/models/yamnet/requirements.txt
+++ b/qai_hub_models/models/yamnet/requirements.txt
@@ -1,2 +1,3 @@
 resampy==0.4.3
 torchaudio>=2.1.2,<2.5.0
+soundfile>=0.13.1


### PR DESCRIPTION
Hi team,

I was trying to setup yamnet on my local development machine and found out the demo application would not execute due to a missing requirement in the [requirements.txt](https://github.com/quic/ai-hub-models/blob/main/qai_hub_models/models/yamnet/requirements.txt).

**Expected behavior**:
The `pip install "qai-hub-models[yamnet]"` command should be sufficient to execute the qai_hub_models.models.yamnet.demo application.

**Observed behavior**:
The demo application requires just one more module to be present on the system, ie: `soundfile` module.

**Issue screenshot**:
<img width="526" alt="image" src="https://github.com/user-attachments/assets/cf984fd6-ef11-4e20-b7e4-13b8c526128b" />

**Proposed fix**:
Added the `soundfile` module to `requirements.txt`.