### PR TITLE
Support new AIMET format in split onnx utils

### DIFF
--- a/qai_hub_models/models/_shared/llm/split_onnx_utils/utils.py
+++ b/qai_hub_models/models/_shared/llm/split_onnx_utils/utils.py
@@ -175,6 +175,13 @@ def _load_encoding(encodingfile: Optional[PathLike], no_merge: bool = False) -> 
     if encodingfile is not None:
         with open(encodingfile) as json_file:
             quant_encoding_dict = json.load(json_file)
+        if isinstance(quant_encoding_dict, list):
+            quant_encoding_dict["activation_encodings"] = {
+                v["name"]: v for v in quant_encoding_dict["activation_encodings"]
+            }
+            quant_encoding_dict["param_encodings"] = {
+                v["name"]: v for v in quant_encoding_dict["param_encodings"]
+            }
         if no_merge:
             return quant_encoding_dict
         all.update(quant_encoding_dict["activation_encodings"])


### PR DESCRIPTION
In splitting an onnx file with the current code, `fill_input_encodings_of_split` can fail because it assumes `encodings["X_params"]` is a dictionary, which is no longer the case with the new AIMET spec for version 1.0.0.
Crucially, this is fixed in the `split_onnx_by_names` method, but not in the `_load_encodings` one, so this is a failure point.