### PR TITLE
fix: adjust output scaling order in OnnxSessionTorchWrapper

### DIFF
--- a/qai_hub_models/utils/onnx_torch_wrapper.py
+++ b/qai_hub_models/utils/onnx_torch_wrapper.py
@@ -692,7 +692,7 @@ class OnnxSessionTorchWrapper(ExecutableModelProtocol):
                 output = outputs[idx]
                 if output_qdq_params is not None:
                     scale, bias = output_qdq_params
-                    output = ((output + bias) * scale).astype(np.float32)
+                    output = (output.astype(np.float32) + bias) * scale
                 processed_outputs.append(output)
             return processed_outputs
 


### PR DESCRIPTION
Solution for issue: https://github.com/quic/ai-hub-models/issues/265

## Instruction
```python
output = ((output + bias) * scale).astype(np.float32)
```
## Values
```python
array([[[[119, 128, 125, ..., 154, 149, 137],
         [134, 132, 131, ..., 136, 140, 148],
         [144, 145, 146, ..., 128, 132, 129],
         ...,
         [129, 117, 119, ..., 124, 125, 122],
         [128, 123, 119, ..., 128, 127, 130],
         [103, 107, 102, ..., 126, 123, 116]]],


       [[[110, 101,  99, ..., 120, 120, 124],
         [109, 105, 112, ..., 116, 119, 124],
         [116, 115, 112, ...,  84,  86,  98],
         ...,
         [133, 134, 129, ..., 128, 131, 137],
         [127, 129, 135, ..., 135, 133, 126],
         [106, 110, 117, ..., 135, 133, 112]]],


       [[[105, 114, 109, ..., 151, 149, 144],
         [118, 123, 120, ..., 125, 128, 125],
         [141, 146, 132, ..., 120, 127, 137],
         ...,
         [149, 146, 139, ..., 125, 126, 127],
         [112, 111, 113, ..., 159, 153, 138],
         [ 91,  86,  81, ..., 127, 126, 117]]],


       ...,


       [[[125, 131, 129, ..., 118, 113, 106],
         [144, 155, 144, ..., 127, 125, 127],
         [143, 140, 142, ..., 125, 124, 132],
         ...,
         [147, 149, 151, ..., 123, 126, 137],
         [116, 117, 120, ..., 137, 122, 112],
         [157, 163, 159, ..., 131, 137, 142]]],


       [[[131, 132, 133, ..., 113, 113, 120],
         [119, 119, 123, ..., 126, 127, 125],
         [146, 146, 135, ..., 133, 134, 134],
         ...,
         [122, 118, 117, ..., 122, 121, 113],
         [128, 132, 137, ..., 132, 128, 118],
         [131, 133, 134, ..., 124, 125, 127]]],


       [[[139, 135, 139, ..., 102, 111, 119],
         [122, 125, 127, ..., 121, 122, 115],
         [109, 106, 113, ..., 130, 127, 123],
         ...,
         [113, 101, 104, ..., 126, 122, 108],
         [117, 121, 132, ..., 131, 134, 127],
         [128, 132, 139, ..., 129, 122, 114]]]],
      shape=(12, 1, 64, 1500), dtype=uint8)


bias = -128
scale = 0.06918466091156006
```
## Exception
```python
Exception has occurred: OverflowError
Python integer -128 out of bounds for uint8
  File "/home/ubuntu/ai-hub-models/qai_hub_models/utils/onnx_torch_wrapper.py", line 698, in _process_outputs
    output = ((output + bias) * scale).astype(np.float32)
               ~~~~~~~^~~~~~
  File "/home/ubuntu/ai-hub-models/qai_hub_models/utils/onnx_torch_wrapper.py", line 594, in run
    return self._process_outputs(session_outputs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/ai-hub-models/qai_hub_models/utils/onnx_torch_wrapper.py", line 575, in forward
    session_outputs = self.run(session_inputs)
                      ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/ai-hub-models/qai_hub_models/utils/onnx_torch_wrapper.py", line 555, in __call__
    return self.forward(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/ai-hub-models/qai_hub_models/models/_shared/hf_whisper/app.py", line 111, in _transcribe_single_chunk
    kv_cache_cross = self.encoder(input_features)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/ai-hub-models/qai_hub_models/models/_shared/hf_whisper/app.py", line 316, in transcribe_tokens
    self._transcribe_single_chunk(x)
  File "/home/ubuntu/ai-hub-models/qai_hub_models/models/_shared/hf_whisper/app.py", line 87, in transcribe
    tokens = self.transcribe_tokens(audio, audio_sample_rate)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/ai-hub-models/runner.py", line 83, in main
    transcription = app.transcribe(audio)
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/ai-hub-models/runner.py", line 89, in <module>
    main()
OverflowError: Python integer -128 out of bounds for uint8
```


