### PR TITLE
fix: cast input to model dtype in VideoMAE to avoid dtype mismatch (closes #293)

### DIFF
--- a/src/qai_hub_models/models/video_mae/model.py
+++ b/src/qai_hub_models/models/video_mae/model.py
@@ -85,6 +85,9 @@ class VideoMAE(KineticsClassifier):
         flat = normalize_image_torchvision(
             flat, image_tensor_has_batch=True, is_video=True
         )
+        # Cast input to model's parameter dtype to avoid dtype mismatch
+        param_dtype = next(self.model.parameters()).dtype
+        flat = flat.to(dtype=param_dtype)
         logits = self.model(flat)
         probs = torch.softmax(logits, dim=1)
         return probs.view(B, V, -1).sum(dim=1)


### PR DESCRIPTION
## What
The VideoMAE model raises a RuntimeError: "expected scalar type BFloat16 but found Float" when the input tensor dtype does not match the model's parameter dtype (e.g., BFloat16). This occurs because the model parameters may be loaded in BFloat16 while the input after normalization remains Float32.

## Fix
Added a line to cast the input tensor to the same dtype as the model's parameters before passing it to the model. This ensures dtype consistency without affecting the model's behavior.

Closes #293